### PR TITLE
some documentation and minor fixes!

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ To get the first blinkstick on your system:
 
     led = new blinkstick.findFirst();
 
+To get all the serial numbers for blinkstick(s) on your system:
+
+    serials = blinkstick.FindAllSerials();
+
 To get all the blinkstick(s) on your system:
 
-    leds = [];
-    serials = blinkstick.findAll();
-    for (i = 0; i < serials.length; i++) leds.push(blinkstick.findBySerial(serials[i]);
+    leds = blinkstick.findAll();
 
 To get the serial number, manufacturer, or description associated with a blinkstick:
 

--- a/blinkstick.js
+++ b/blinkstick.js
@@ -466,9 +466,25 @@ module.exports = {
 	
 	/**
 	 * Find all attached BlinkStick devices.
-	 * @returns {Array} serial numbers corresponding to BlinkSticks.
+	 * @returns {Array} BlinkSticks.
 	 */
 	findAll: function () {
+		var devices = findBlinkSticks(),
+		    sticks = [],
+		    i = [];
+
+		for (i = 0; i < devices.length; i++) sticks.push(new BlinkStick(devices[i].deviceDescriptor.iSerialNumber));
+	        return sticks;
+	},
+
+
+
+	
+	/**
+	 * Find all attached BlinkStick devices.
+	 * @returns {Array} serial numbers corresponding to BlinkSticks.
+	 */
+	findAllSerials: function () {
 		var devices = findBlinkSticks(),
 		    serials = [],
 		    i = [];


### PR DESCRIPTION
findAll() now documented as returning an array of serial numbers

findBySerial now returns either a BlinkStick or unknown (before it was
returning a device)
