### PR TITLE
Update dependencies for newer versions of code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "url": "https://github.com/arvydas/blinkstick-node"
   },
   "dependencies": {
-    "usb": "1.0.4"
+    "usb": "^1.1.2"
   }
 }


### PR DESCRIPTION
usb v1.1.2 works on Raspberry Pi 2 Model B running Node v4.2.3 on Raspbian Jessie

There is nothing wrong with the blinkstick library, only that it depends on versin of `usb` which does not support nodejs v4+.