### PR TITLE
Bugfix: getColors does not return blue for last LED

### DIFF
--- a/blinkstick.js
+++ b/blinkstick.js
@@ -648,7 +648,7 @@ BlinkStick.prototype.getColors = function (count, callback) {
     this.getFeatureReport(params.reportId, params.maxLeds * 3 + 2, function (err, buffer) {
         if (callback) {
             if (typeof(buffer) !== 'undefined') {
-                buffer = buffer.slice(2, buffer.length -1);
+                buffer = buffer.slice(2, buffer.length);
             }
 
             callback(err, buffer);


### PR DESCRIPTION
My BlinkStick Square wont return a value for blue for the last LED. So pulse is not showing the correct color on the last LED (Index 7). I changed the slicing of the buffer and now everything works fine.